### PR TITLE
Add more matchers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4 [☰](https://github.com/carllerche/hamcrest-rust/compare/0.1.3...0.1.4)
+
+* Logical matchers `all_of`, `any_of`, comparison matchers `type_of`, `anything`, #47
+
 ## 0.1.3 [☰](https://github.com/carllerche/hamcrest-rust/compare/0.1.2...0.1.3)
 
 * Comparison matchers `less_than`, `less_than_or_equal_to`, `greater_than`, `greater_than_or_equal_to`. #43

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ authors = [
   "Yehuda Katz <wycats@gmail.com>",
   "Ian Létourneau <letourneau.ian@gmail.com>",
   "Matt LaChance <mattlach@umich.edu>",
+  "Flier Lu <flier.lu@gmail.com>",
 ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ assert_that!(None, is(none::<int>()));
 assert_that!(Some(1), is_not(none::<int>()));
 ```
 
+### anything
+
+``` rust
+assert_that!(42, is(anything()));
+assert_that!("test", is(anything()));
+```
+
 ### contains, contains\_exactly, contains\_in order
 
 ``` rust
@@ -86,6 +93,33 @@ assert_that!(&vec!(1i, 2, 3), not(contains(vec!(1i, 3)).in_order()));
 ``` rust
 assert_that!("1234", matches_regex(r"\d"));
 assert_that!("abc", does_not(match_regex(r"\d")));
+```
+
+### type_of
+
+``` rust
+assert_that!(123usize, is(type_of::<usize>()));
+assert_that!("test", is(type_of::<&str>()));
+```
+
+### all_of
+
+``` rust
+assert_that!(4, all_of!(less_than(5), greater_than(3)));
+assert_that!(
+    &vec![1, 2, 3],
+    all_of!(contains(vec![1, 2]), not(contains(vec![4])))
+);
+```
+
+### any_of
+
+``` rust
+assert_that!(4, any_of!(less_than(2), greater_than(3)));
+assert_that!(
+    &vec![1, 2, 3],
+    any_of!(contains(vec![1, 2, 5]), not(contains(vec![4])))
+);
 ```
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,4 +60,5 @@ pub mod prelude {
     pub use matchers::vecs::contains;
     pub use matchers::vecs::of_len;
     pub use matchers::anything::anything;
+    pub use matchers::type_of::type_of;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,4 +59,5 @@ pub mod prelude {
     pub use matchers::regex::matches_regex;
     pub use matchers::vecs::contains;
     pub use matchers::vecs::of_len;
+    pub use matchers::anything::anything;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,4 +61,8 @@ pub mod prelude {
     pub use matchers::vecs::of_len;
     pub use matchers::anything::anything;
     pub use matchers::type_of::type_of;
+    pub use matchers::all_of::all_of;
+    pub use matchers::all_of::all_of as and;
+    pub use matchers::any_of::any_of;
+    pub use matchers::any_of::any_of as or;
 }

--- a/src/matchers/all_of.rs
+++ b/src/matchers/all_of.rs
@@ -1,8 +1,4 @@
-// Copyright 2014 Carl Lerche, Steve Klabnik, Alex Crichton, Yehuda Katz,
-//                Ben Longbons
-// Copyright 2015 Carl Lerche, Alex Crichton, Robin Gloster
-// Copyright 2016 Urban Hafner
-// Copyright 2017 Matt LaChance
+// Copyright 2017 Flier Lu
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/matchers/all_of.rs
+++ b/src/matchers/all_of.rs
@@ -1,0 +1,197 @@
+// Copyright 2014 Carl Lerche, Steve Klabnik, Alex Crichton, Yehuda Katz,
+//                Ben Longbons
+// Copyright 2015 Carl Lerche, Alex Crichton, Robin Gloster
+// Copyright 2016 Urban Hafner
+// Copyright 2017 Matt LaChance
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt::{self, Display};
+use std::marker::PhantomData;
+
+use core::*;
+
+pub struct AllOf<T, M>(M, PhantomData<T>);
+
+pub fn all_of<T, M>(matchers: M) -> AllOf<T, M> {
+    AllOf(matchers, PhantomData)
+}
+
+#[macro_export]
+macro_rules! all_of {
+    ($( $arg:expr ),*) => ($crate::matchers::all_of::all_of(($( $arg ),*)))
+}
+
+impl<T, M0, M1> Display for AllOf<T, (M0, M1)>
+where
+    M0: Display,
+    M1: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1) = self.0;
+
+        write!(f, "all of ({}, {})", m0, m1)
+    }
+}
+
+impl<T, M0, M1> Matcher<T> for AllOf<T, (M0, M1)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1) = self.0;
+
+        m0.matches(actual.clone())?;
+        m1.matches(actual.clone())?;
+
+        success()
+    }
+}
+
+impl<T, M0, M1, M2> Display for AllOf<T, (M0, M1, M2)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2) = self.0;
+
+        write!(f, "all of ({}, {}, {})", m0, m1, m2)
+    }
+}
+
+impl<T, M0, M1, M2> Matcher<T> for AllOf<T, (M0, M1, M2)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2) = self.0;
+
+        m0.matches(actual.clone())?;
+        m1.matches(actual.clone())?;
+        m2.matches(actual.clone())?;
+
+        success()
+    }
+}
+
+impl<T, M0, M1, M2, M3> Display for AllOf<T, (M0, M1, M2, M3)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+    M3: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2, ref m3) = self.0;
+
+        write!(f, "all of ({}, {}, {}, {})", m0, m1, m2, m3)
+    }
+}
+
+impl<T, M0, M1, M2, M3> Matcher<T> for AllOf<T, (M0, M1, M2, M3)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+    M3: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2, ref m3) = self.0;
+
+        m0.matches(actual.clone())?;
+        m1.matches(actual.clone())?;
+        m2.matches(actual.clone())?;
+        m3.matches(actual.clone())?;
+
+        success()
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4> Display for AllOf<T, (M0, M1, M2, M3, M4)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+    M3: Display,
+    M4: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4) = self.0;
+
+        write!(f, "all of ({}, {}, {}, {}, {})", m0, m1, m2, m3, m4)
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4> Matcher<T> for AllOf<T, (M0, M1, M2, M3, M4)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+    M3: Matcher<T>,
+    M4: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4) = self.0;
+
+        m0.matches(actual.clone())?;
+        m1.matches(actual.clone())?;
+        m2.matches(actual.clone())?;
+        m3.matches(actual.clone())?;
+        m4.matches(actual.clone())?;
+
+        success()
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4, M5> Display for AllOf<T, (M0, M1, M2, M3, M4, M5)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+    M3: Display,
+    M4: Display,
+    M5: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4, ref m5) = self.0;
+
+        write!(f, "all of ({}, {}, {}, {}, {}, {})", m0, m1, m2, m3, m4, m5)
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4, M5> Matcher<T> for AllOf<T, (M0, M1, M2, M3, M4, M5)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+    M3: Matcher<T>,
+    M4: Matcher<T>,
+    M5: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4, ref m5) = self.0;
+
+        m0.matches(actual.clone())?;
+        m1.matches(actual.clone())?;
+        m2.matches(actual.clone())?;
+        m3.matches(actual.clone())?;
+        m4.matches(actual.clone())?;
+        m5.matches(actual.clone())?;
+
+        success()
+    }
+}

--- a/src/matchers/any_of.rs
+++ b/src/matchers/any_of.rs
@@ -43,8 +43,9 @@ where
     fn matches(&self, actual: T) -> MatchResult {
         let (ref m0, ref m1) = self.0;
 
-        m0.matches(actual.clone())
-            .or_else(|_| m1.matches(actual.clone()))
+        m0.matches(actual.clone()).or_else(
+            |_| m1.matches(actual.clone()),
+        )
     }
 }
 

--- a/src/matchers/any_of.rs
+++ b/src/matchers/any_of.rs
@@ -1,8 +1,4 @@
-// Copyright 2014 Carl Lerche, Steve Klabnik, Alex Crichton, Yehuda Katz,
-//                Ben Longbons
-// Copyright 2015 Carl Lerche, Alex Crichton, Robin Gloster
-// Copyright 2016 Urban Hafner
-// Copyright 2017 Matt LaChance
+// Copyright 2017 Flier Lu
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -47,9 +43,8 @@ where
     fn matches(&self, actual: T) -> MatchResult {
         let (ref m0, ref m1) = self.0;
 
-        m0.matches(actual.clone()).or_else(
-            |_| m1.matches(actual.clone()),
-        )
+        m0.matches(actual.clone())
+            .or_else(|_| m1.matches(actual.clone()))
     }
 }
 

--- a/src/matchers/any_of.rs
+++ b/src/matchers/any_of.rs
@@ -1,0 +1,188 @@
+// Copyright 2014 Carl Lerche, Steve Klabnik, Alex Crichton, Yehuda Katz,
+//                Ben Longbons
+// Copyright 2015 Carl Lerche, Alex Crichton, Robin Gloster
+// Copyright 2016 Urban Hafner
+// Copyright 2017 Matt LaChance
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt::{self, Display};
+use std::marker::PhantomData;
+
+use core::*;
+
+pub struct AnyOf<T, M>(M, PhantomData<T>);
+
+pub fn any_of<T, M>(matchers: M) -> AnyOf<T, M> {
+    AnyOf(matchers, PhantomData)
+}
+
+#[macro_export]
+macro_rules! any_of {
+    ($( $arg:expr ),*) => ($crate::matchers::any_of::any_of(($( $arg ),*)))
+}
+
+impl<T, M0, M1> Display for AnyOf<T, (M0, M1)>
+where
+    M0: Display,
+    M1: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1) = self.0;
+
+        write!(f, "any of ({}, {})", m0, m1)
+    }
+}
+
+impl<T, M0, M1> Matcher<T> for AnyOf<T, (M0, M1)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1) = self.0;
+
+        m0.matches(actual.clone()).or_else(
+            |_| m1.matches(actual.clone()),
+        )
+    }
+}
+
+impl<T, M0, M1, M2> Display for AnyOf<T, (M0, M1, M2)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2) = self.0;
+
+        write!(f, "any of ({}, {}, {})", m0, m1, m2)
+    }
+}
+
+impl<T, M0, M1, M2> Matcher<T> for AnyOf<T, (M0, M1, M2)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2) = self.0;
+
+        m0.matches(actual.clone())
+            .or_else(|_| m1.matches(actual.clone()))
+            .or_else(|_| m2.matches(actual.clone()))
+    }
+}
+
+impl<T, M0, M1, M2, M3> Display for AnyOf<T, (M0, M1, M2, M3)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+    M3: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2, ref m3) = self.0;
+
+        write!(f, "any of ({}, {}, {}, {})", m0, m1, m2, m3)
+    }
+}
+
+impl<T, M0, M1, M2, M3> Matcher<T> for AnyOf<T, (M0, M1, M2, M3)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+    M3: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2, ref m3) = self.0;
+
+        m0.matches(actual.clone())
+            .or_else(|_| m1.matches(actual.clone()))
+            .or_else(|_| m2.matches(actual.clone()))
+            .or_else(|_| m3.matches(actual.clone()))
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4> Display for AnyOf<T, (M0, M1, M2, M3, M4)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+    M3: Display,
+    M4: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4) = self.0;
+
+        write!(f, "any of ({}, {}, {}, {}, {})", m0, m1, m2, m3, m4)
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4> Matcher<T> for AnyOf<T, (M0, M1, M2, M3, M4)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+    M3: Matcher<T>,
+    M4: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4) = self.0;
+
+        m0.matches(actual.clone())
+            .or_else(|_| m1.matches(actual.clone()))
+            .or_else(|_| m2.matches(actual.clone()))
+            .or_else(|_| m3.matches(actual.clone()))
+            .or_else(|_| m4.matches(actual.clone()))
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4, M5> Display for AnyOf<T, (M0, M1, M2, M3, M4, M5)>
+where
+    M0: Display,
+    M1: Display,
+    M2: Display,
+    M3: Display,
+    M4: Display,
+    M5: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4, ref m5) = self.0;
+
+        write!(f, "any of ({}, {}, {}, {}, {}, {})", m0, m1, m2, m3, m4, m5)
+    }
+}
+
+impl<T, M0, M1, M2, M3, M4, M5> Matcher<T> for AnyOf<T, (M0, M1, M2, M3, M4, M5)>
+where
+    T: Clone,
+    M0: Matcher<T>,
+    M1: Matcher<T>,
+    M2: Matcher<T>,
+    M3: Matcher<T>,
+    M4: Matcher<T>,
+    M5: Matcher<T>,
+{
+    fn matches(&self, actual: T) -> MatchResult {
+        let (ref m0, ref m1, ref m2, ref m3, ref m4, ref m5) = self.0;
+
+        m0.matches(actual.clone())
+            .or_else(|_| m1.matches(actual.clone()))
+            .or_else(|_| m2.matches(actual.clone()))
+            .or_else(|_| m3.matches(actual.clone()))
+            .or_else(|_| m4.matches(actual.clone()))
+            .or_else(|_| m5.matches(actual.clone()))
+    }
+}

--- a/src/matchers/anything.rs
+++ b/src/matchers/anything.rs
@@ -1,0 +1,32 @@
+// Copyright 2014 Steve Klabnik, Valerii Hiora, Oliver Mader
+// Copyright 2015 Carl Lerche, Oliver Mader, Alex Crichton, Graham Dennis,
+//                Tamir Duberstein, Robin Gloster
+// Copyright 2016 Urban Hafner
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use std::fmt::{self, Display, Formatter};
+
+use core::*;
+
+pub struct Anything;
+
+impl Display for Anything {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "anything")
+    }
+}
+
+impl<T> Matcher<T> for Anything {
+    fn matches(&self, _: T) -> MatchResult {
+        success()
+    }
+}
+
+/// always matches, useful if you don't care what the object under test is
+pub fn anything() -> Anything {
+    Anything
+}

--- a/src/matchers/anything.rs
+++ b/src/matchers/anything.rs
@@ -1,7 +1,4 @@
-// Copyright 2014 Steve Klabnik, Valerii Hiora, Oliver Mader
-// Copyright 2015 Carl Lerche, Oliver Mader, Alex Crichton, Graham Dennis,
-//                Tamir Duberstein, Robin Gloster
-// Copyright 2016 Urban Hafner
+// Copyright 2017 Flier Lu
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/matchers/existing_path.rs
+++ b/src/matchers/existing_path.rs
@@ -32,12 +32,16 @@ impl ExistingPath {
         let metadata = fs::metadata(actual);
         match self.path_type {
             PathType::File => {
-                expect(metadata.map(|m| m.is_file()).unwrap_or(false),
-                       format!("`{}` was not a file", actual.display()))
+                expect(
+                    metadata.map(|m| m.is_file()).unwrap_or(false),
+                    format!("`{}` was not a file", actual.display()),
+                )
             }
             PathType::Dir => {
-                expect(metadata.map(|m| m.is_dir()).unwrap_or(false),
-                       format!("`{}` was not a dir", actual.display()))
+                expect(
+                    metadata.map(|m| m.is_dir()).unwrap_or(false),
+                    format!("`{}` was not a dir", actual.display()),
+                )
             }
             _ => success(),
         }
@@ -58,9 +62,10 @@ impl<'a> Matcher<&'a PathBuf> for ExistingPath {
 
 impl<'a> Matcher<&'a Path> for ExistingPath {
     fn matches(&self, actual: &Path) -> MatchResult {
-        expect(fs::metadata(actual).is_ok(),
-               format!("{} was missing", actual.display()))
-            .and(self.match_path_type(actual))
+        expect(
+            fs::metadata(actual).is_ok(),
+            format!("{} was missing", actual.display()),
+        ).and(self.match_path_type(actual))
     }
 }
 

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -16,3 +16,5 @@ pub mod regex;
 pub mod vecs;
 pub mod anything;
 pub mod type_of;
+pub mod all_of;
+pub mod any_of;

--- a/src/matchers/type_of.rs
+++ b/src/matchers/type_of.rs
@@ -1,0 +1,38 @@
+// Copyright 2014 Steve Klabnik, Valerii Hiora, Oliver Mader
+// Copyright 2015 Carl Lerche, Oliver Mader, Alex Crichton, Graham Dennis,
+//                Tamir Duberstein, Robin Gloster
+// Copyright 2016 Urban Hafner
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use std::any::TypeId;
+use std::fmt::{self, Display, Formatter};
+
+use core::*;
+
+pub struct TypeOf(TypeId);
+
+impl Display for TypeOf {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "type_of({:?})", self.0)
+    }
+}
+
+impl<T: 'static> Matcher<T> for TypeOf {
+    fn matches(&self, _: T) -> MatchResult {
+        let type_id = TypeId::of::<T>();
+
+        if self.0 == type_id {
+            success()
+        } else {
+            Err(format!("type_of({:?})", type_id))
+        }
+    }
+}
+
+pub fn type_of<T: 'static>() -> TypeOf {
+    TypeOf(TypeId::of::<T>())
+}

--- a/src/matchers/type_of.rs
+++ b/src/matchers/type_of.rs
@@ -17,7 +17,7 @@ pub struct TypeOf(TypeId);
 
 impl Display for TypeOf {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "type_of({:?})", self.0)
+        write!(f, "type of {:?}", self.0)
     }
 }
 
@@ -28,7 +28,7 @@ impl<T: 'static> Matcher<T> for TypeOf {
         if self.0 == type_id {
             success()
         } else {
-            Err(format!("type_of({:?})", type_id))
+            Err(format!("type of {:?}", type_id))
         }
     }
 }

--- a/src/matchers/type_of.rs
+++ b/src/matchers/type_of.rs
@@ -1,7 +1,4 @@
-// Copyright 2014 Steve Klabnik, Valerii Hiora, Oliver Mader
-// Copyright 2015 Carl Lerche, Oliver Mader, Alex Crichton, Graham Dennis,
-//                Tamir Duberstein, Robin Gloster
-// Copyright 2016 Urban Hafner
+// Copyright 2017 Flier Lu
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/matchers/vecs.rs
+++ b/src/matchers/vecs.rs
@@ -15,7 +15,7 @@ use std::vec::Vec;
 
 use core::*;
 
-#[derive(Clone,Copy)]
+#[derive(Clone, Copy)]
 pub struct OfLen {
     len: usize,
 }
@@ -87,9 +87,11 @@ impl<'a, T: fmt::Debug + PartialEq + Clone> Matcher<&'a Vec<T>> for Contains<T> 
         }
 
         if self.in_order && !contains_in_order(actual, &self.items) {
-            return Err(format!("{} does not contain {} in order",
-                               Pretty(&actual),
-                               Pretty(&self.items)));
+            return Err(format!(
+                "{} does not contain {} in order",
+                Pretty(&actual),
+                Pretty(&self.items)
+            ));
         }
 
         success()

--- a/tests/all_of.rs
+++ b/tests/all_of.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 Urban Hafner
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate hamcrest;
+
+mod all_of {
+
+    use hamcrest::prelude::*;
+
+    #[test]
+    fn ints_less_than_and_greater_than() {
+        assert_that!(4, all_of!(less_than(5), greater_than(3)));
+    }
+
+    #[test]
+    fn vec_contains() {
+        assert_that!(
+            &vec![1, 2, 3],
+            all_of!(contains(vec![1, 2]), not(contains(vec![4])))
+        );
+    }
+}

--- a/tests/any_of.rs
+++ b/tests/any_of.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 Urban Hafner
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate hamcrest;
+
+mod any_of {
+
+    use hamcrest::prelude::*;
+
+    #[test]
+    fn ints_less_than_and_greater_than() {
+        assert_that!(4, any_of!(less_than(2), greater_than(3)));
+    }
+
+    #[test]
+    fn vec_contains() {
+        assert_that!(
+            &vec![1, 2, 3],
+            any_of!(contains(vec![1, 2, 5]), not(contains(vec![4])))
+        );
+    }
+}

--- a/tests/anything.rs
+++ b/tests/anything.rs
@@ -6,12 +6,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub mod close_to;
-pub mod compared_to;
-pub mod equal_to;
-pub mod existing_path;
-pub mod is;
-pub mod none;
-pub mod regex;
-pub mod vecs;
-pub mod anything;
+#[macro_use]
+extern crate hamcrest;
+
+mod anything {
+
+    use hamcrest::prelude::*;
+
+    #[test]
+    fn usize_is_anything() {
+        assert_that!(123, is(anything()));
+    }
+
+    #[test]
+    fn str_is_anything() {
+        assert_that!("test", is(anything()));
+    }
+
+}

--- a/tests/type_of.rs
+++ b/tests/type_of.rs
@@ -6,13 +6,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub mod close_to;
-pub mod compared_to;
-pub mod equal_to;
-pub mod existing_path;
-pub mod is;
-pub mod none;
-pub mod regex;
-pub mod vecs;
-pub mod anything;
-pub mod type_of;
+#[macro_use]
+extern crate hamcrest;
+
+mod type_of {
+
+    use hamcrest::prelude::*;
+
+    #[test]
+    fn usize_is_type_of_usize() {
+        assert_that!(123usize, is(type_of::<usize>()));
+    }
+
+    #[test]
+    fn str_is_type_of_str() {
+        assert_that!("test", is(type_of::<&str>()));
+    }
+
+}


### PR DESCRIPTION
- `anything` always matches, useful if you don't care what the object under test is
- `type_of` test type
- `all_of` matches if all matchers match, short circuits (like `&&`)
- `any_of` matches if any matchers match, short circuits (like `||`)

